### PR TITLE
Avoid excessive reset

### DIFF
--- a/rtmouse.c
+++ b/rtmouse.c
@@ -13,7 +13,7 @@
 MODULE_AUTHOR("RT Corporation");
 MODULE_DESCRIPTION("A simple driver for control Jetson Nano");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("0.0.2");
+MODULE_VERSION("0.1.0");
 
 /* --- GPIO Pins --- */
 #define gpioLED0 13       // PIN22


### PR DESCRIPTION
パルスの周期が変化する場合はICを毎回リスタートしています。デバイスファイルに書き込まれる値が変化していないときはICに司令を出さないようにすることでリスタート回数を減らし、パルスを安定させます。