### PR TITLE
Hotfix to work around the problem of SPI_CS

### DIFF
--- a/drivers/rtmouse/rtmouse.c
+++ b/drivers/rtmouse/rtmouse.c
@@ -4,7 +4,7 @@
  * rtmouse.c
  * Jetson Nano Mouse device driver
  *
- * Version: 0.1.3
+ * Version: 0.1.4
  *
  * Copyright (C) 2019-2020 RT Corporation <shop@rt-net.jp>
  *

--- a/drivers/rtmouse/rtmouse.c
+++ b/drivers/rtmouse/rtmouse.c
@@ -153,9 +153,9 @@ static int spi_bus_num = 0;
 static int spi_chip_select = 0;
 #endif
 #ifdef ALTERNATIVE_SPI_CS
-static int spi_chip_select = 1;  // To work around the problem of SPI_CS not working properly.
+// To work around the problem of SPI_CS not working properly.
+static int spi_chip_select = 1;
 #endif
-
 
 /* --- A/D Parameters --- */
 #define MCP320X_PACKET_SIZE 3
@@ -488,8 +488,8 @@ static ssize_t sensor_read(struct file *filep, char __user *buf, size_t count,
 	if (*f_pos > 0)
 		return 0; /* End of file */
 
-	/* get values through MCP3204 */
 #ifndef ALTERNATIVE_SPI_CS
+	/* get values through MCP3204 */
 	/* Right side */
 	or = mcp3204_get_value(R_AD_CH);
 	gpio_set_value(GPIO_SEN_R, 1);
@@ -520,6 +520,7 @@ static ssize_t sensor_read(struct file *filep, char __user *buf, size_t count,
 	udelay(usecs);
 #endif
 #ifdef ALTERNATIVE_SPI_CS
+	/* get values through MCP3204 */
 	/* Right side */
 	gpio_set_value(GPIO_SPI_CS, 0);
 	or = mcp3204_get_value(R_AD_CH);

--- a/drivers/rtmouse/rtmouse.c
+++ b/drivers/rtmouse/rtmouse.c
@@ -4,7 +4,7 @@
  * rtmouse.c
  * Jetson Nano Mouse device driver
  *
- * Version: 0.1.4
+ * Version: 0.1.5
  *
  * Copyright (C) 2019-2020 RT Corporation <shop@rt-net.jp>
  *
@@ -39,7 +39,7 @@
 MODULE_AUTHOR("RT Corporation");
 MODULE_DESCRIPTION("A device driver of Jetson Nano Mouse");
 MODULE_LICENSE("GPL");
-MODULE_VERSION("0.1.4");
+MODULE_VERSION("0.1.5");
 
 /* --- Options --- */
 #define ALTERNATIVE_SPI_CS


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->

JetPack 4.4.1よりSPI_CSの信号がうまく出力されていないためGPIOピンとして直接操作します
gpio20（26番ピン）を他の用途で使っている場合はこのオプションは利用できません。

![image](https://user-images.githubusercontent.com/3256629/142413068-022d60cf-5f04-4d4f-b4fb-f36eecfc8447.png)
https://www.slideshare.net/NVIDIAJapan/getting-started-with-jetson-nano より引用

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->

しません


# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

jnmouse_jp451_v3.zip  をJetson Nano Mouse実機にインストールして動作確認

https://github.com/rt-net/jnmouse_utils/tree/master/setup-scripts#option-1

# Any other comments?
<!-- その他コメントはありますか？ -->


# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
