### PR TITLE
Add external clock mode option

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -8,7 +8,16 @@ A linux device driver of Jetson Nano Mouse
 
 Run "Jetson-IO" to enable `spi1`.  See the [wiki](https://github.com/rt-net/JetsonNanoMouse/wiki/Jetson-IO%E3%82%92%E7%94%A8%E3%81%84%E3%81%A6SPI1%E3%82%92%E6%9C%89%E5%8A%B9%E5%8C%96) for details.
 
-After downloading(`git clone`) this repository, run the following commands in the directory.
+First, download this repository using `git clone` command.
+
+```sh
+git clone https://github.com/rt-net/JetsonNanoMouse.git
+cd JetsonNanoMouse
+```
+
+Next, modify the option defined in [`drivers/rtmouse/rtmouse.c`](drivers/rtmouse/rtmouse.c).
+
+Finally, run the following commands in the directory.
 
 ```sh
 make build
@@ -16,6 +25,16 @@ sudo make install
 ```
 
 Make sure that device files (`/dev/rtlightsensor0`, `/dev/rtled0`, and so on) has been created.
+
+## Options
+
+Valid options for [`drivers/rtmouse/rtmouse.c`](drivers/rtmouse/rtmouse.c).
+
+| Option | Enabled | Disabled |
+| --- | --- | --- |
+| USE_EXTERNAL_CLOCK | Use external clock in PWM output IC to motor driver *1 | Use internal clock in PWM output IC to motor driver |
+
+*1 Expected to reduce the difference in speed between the left and right motors. （[#16](https://github.com/rt-net/JetsonNanoMouse/issues/16)）
 
 ## Sample program
 

--- a/README.en.md
+++ b/README.en.md
@@ -82,3 +82,34 @@ This project includes the code to control PCA9685([adafruit/Adafruit_Python_PCA9
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 ```
+
+This project includes the code to control PCA9685([adafruit/Adafruit-PWM-Servo-Driver-Library](https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library)) licensed under the 3-clause BSD License.
+
+```
+Software License Agreement (BSD License)
+
+Copyright (c) 2012, Adafruit Industries
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,14 @@ Jetson Nano Mouseのデバイスドライバです。
 
 Jetson-IOを実行して`spi1`を有効にします。詳細は[wiki](https://github.com/rt-net/JetsonNanoMouse/wiki/Jetson-IO%E3%82%92%E7%94%A8%E3%81%84%E3%81%A6SPI1%E3%82%92%E6%9C%89%E5%8A%B9%E5%8C%96)を参照してください。
 
-このリポジトリを`git clone`でダウンロードし、
+このリポジトリを`git clone`でダウンロードします。
 
 ```sh
 git clone https://github.com/rt-net/JetsonNanoMouse.git
 cd JetsonNanoMouse
 ```
+
+必要に応じて[`drivers/rtmouse/rtmouse.c`](drivers/rtmouse/rtmouse.c)のオプションを編集します。
 
 ダウンロードしたディレクトリ内で以下のコマンドを実行します。
 
@@ -25,6 +27,16 @@ sudo make install
 ```
 
 `/dev/rtlightsensor0`や`/dev/rtled0`などのデバイスファイルが作成されていることを確認します。
+
+## オプション
+
+[`drivers/rtmouse/rtmouse.c`](drivers/rtmouse/rtmouse.c)のオプションは以下の通りです。
+
+| オプション | 有効な場合 | 無効な場合 |
+| --- | --- | --- |
+| USE_EXTERNAL_CLOCK | モータドライバへの信号出力ICで外部クロックを使用 ※1 | モータドライバへの信号出力ICで内部クロックを使用 |
+
+※1 左右のモータの回転数差の低減が期待できます（[#16](https://github.com/rt-net/JetsonNanoMouse/issues/16)）
 
 ## サンプルプログラム
 

--- a/README.md
+++ b/README.md
@@ -93,3 +93,34 @@ This project includes the code to control PCA9685([adafruit/Adafruit_Python_PCA9
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 ```
+
+This project includes the code to control PCA9685([adafruit/Adafruit-PWM-Servo-Driver-Library](https://github.com/adafruit/Adafruit-PWM-Servo-Driver-Library)) licensed under the 3-clause BSD License.
+
+```
+Software License Agreement (BSD License)
+
+Copyright (c) 2012, Adafruit Industries
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/drivers/rtmouse/rtmouse.c
+++ b/drivers/rtmouse/rtmouse.c
@@ -41,6 +41,9 @@ MODULE_DESCRIPTION("A device driver of Jetson Nano Mouse");
 MODULE_LICENSE("GPL");
 MODULE_VERSION("0.1.3");
 
+/* --- Options --- */
+//#define USE_EXTERNAL_CLOCK
+
 /* --- GPIO Pins --- */
 #define GPIO_LED0 13	 // PIN22
 #define GPIO_LED1 15	 // PIN18
@@ -177,8 +180,6 @@ static int spi_chip_select = 0;
 #define PCA9685_SLEEP 0x10
 #define PCA9685_ALLCALL 0x01
 #define PCA9685_OUTDRV 0x04
-
-//#define USE_EXTERNAL_CLOCK
 
 #ifdef USE_EXTERNAL_CLOCK
 #define PCA9685_CLOCK 0x40


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->


現状のソフトウェアではモータドライバへのPWMを出力するIC（左右でそれぞれ1つ）のクロックのソースを内蔵クロックとしているため、左右のモータの回転数差が生じる場合があります。
共通の外部クロックを使うことによって左右のPWMのずれを低減させます。

詳細: https://github.com/rt-net/JetsonNanoMouse/issues/16

__`RT-JNM-202103`と記載がある基板のみ本オプションを使用できます。__

基板については https://github.com/rt-net/JetsonNanoMouse_Hardware/blob/main/circuit_diagram/README.md に詳細を記載しています。

# Does this close any currently open issues?
<!-- このPRはオープンになっているissueをクローズしますか？ -->
close #16 

# How has this been tested?
<!-- このPRはどのようにテストしましたか？ -->

#16 のサンプルを使ってカウンターの差が縮まることを確認しました
## before
```
Motor On
Reset counter
Move forward
count_l:11460, count_r:11338
Reset counter
Move backward
count_l:11726, count_r:11602
Reset counter
Motor Off
```
## after
```
Motor On
Reset counter
Move forward
count_l:12140, count_r:12136
Reset counter
Move backward
count_l:11584, count_r:11580
Reset counter
Motor Off
```

# Any other comments?
<!-- その他コメントはありますか？ -->

対応していない基板でオプションを有効にして上記サンプルを実行するとモータは回りません。

```
Motor On
Reset counter
Move forward
count_l:0, count_r:0
Reset counter
Move backward
count_l:0, count_r:0
Reset counter
Motor Off
```

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
